### PR TITLE
Mods to work with MacOS11 for testing old functionality.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,10 +7,10 @@
 define([psi_version],[3.4.0])
 define([psi_buildid],[alpha])
 define([psi_bugreport],[psicode@users.sourceforge.net])
-AC_PREREQ(2.57)
+AC_PREREQ([2.71])
 AC_INIT([psi],[psi_version],[psi_bugreport])
 
-AC_CONFIG_HEADER(include/psiconfig.h)
+AC_CONFIG_HEADERS([include/psiconfig.h])
 
 PSI_VERSION=psi_version
 PSI_BUILDID=psi_buildid
@@ -243,7 +243,7 @@ AC_SUBST(FC_SYMBOL)
 AC_PROG_RANLIB
 AC_PROG_CPP
 AC_PROG_CXXCPP
-AC_PROG_LEX
+AC_PROG_LEX([yywrap])
 AC_PROG_YACC
 AC_PROG_INSTALL
 AC_PROG_LN_S
@@ -477,7 +477,8 @@ LIBS=$SAVE_LIBS
 # Check for libcompat.a availability
 #case $target_vendor in
 #  apple)
-#    AC_HAVE_LIBRARY(compat,CLIBS="-lcompat $CLIBS",AC_MSG_ERROR([Missing libcompat.a: See http://www.opensource.apple.com/ for more information]))
+#    AC_CHECK_LIB([compat],[main],[CLIBS="-lcompat $CLIBS"],[AC_MSG_ERROR(Missing libcompat.a: See http://www.opensource.apple.com/ for more information)],[])ac_cv_lib_compat=ac_cv_lib_compat_main
+
 #    echo "$CLIBS"
 #  ;;
 #esac
@@ -549,7 +550,7 @@ if test X$HAVE_RUBY = Xyes; then
   AC_MSG_CHECKING([for ruby_init])
   REF_LIBS=$LIBS  LIBS="$RUBYLIB $LIBS"
   REF_CPPFLAGS=$CPPFLAGS CPPFLAGS="$REF_CPPFLAGS $RUBYINC"
-  AC_LINK_IFELSE(
+  AC_LINK_IFELSE([
     AC_LANG_PROGRAM(
       [[#include <ruby.h>
       ]],
@@ -562,7 +563,7 @@ if test X$HAVE_RUBY = Xyes; then
     AC_MSG_RESULT(yes),
     HAVE_RUBY=no
     AC_MSG_RESULT(no)
-  )
+  ])
   LIBS=$REF_LIBS
   CPPFLAGS=$REF_CPPFLAGS
   fi

--- a/src/lib/libderiv/build_libderiv.c
+++ b/src/lib/libderiv/build_libderiv.c
@@ -7,6 +7,7 @@
 
 #include <math.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <libint/libint.h>
 #include "build_libderiv.h"
 

--- a/src/lib/libderiv/build_libderiv.h
+++ b/src/lib/libderiv/build_libderiv.h
@@ -10,6 +10,7 @@
 #define EMIT_DERIV2_MANAGERS 0  /*--- whether to produce manager functions that compute
 				   second derivatives only ---*/
 
+void punt(char* str);
 
 typedef struct {
 

--- a/src/lib/libderiv/emit_deriv12_managers.c
+++ b/src/lib/libderiv/emit_deriv12_managers.c
@@ -8,6 +8,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 #include <libint/libint.h>
 #include "mem_man.h"
 #include "build_libderiv.h"

--- a/src/lib/libderiv/emit_deriv1_managers.c
+++ b/src/lib/libderiv/emit_deriv1_managers.c
@@ -8,6 +8,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 #include <libint/libint.h>
 #include "mem_man.h"
 #include "build_libderiv.h"
@@ -38,6 +39,13 @@ typedef struct node{
   int marked;             /* Flag indicating that this node has been computed */
   int target;             /* Flag indicating that this node is among targets */
   } class;
+
+int mk_dhrr_node(class node, class *allnodes, int new);
+int mark_dhrr_parents(int n, class *allnodes, int rent);
+int alloc_mem_dhrr(class *nodes);
+int mk_deriv_node(class node, class *allnodes, int new);
+int mark_parents(int n, class *allnodes, int rent);
+int alloc_mem_vrr(class *nodes);
 
 static int first_hrr_to_compute = 0; /* Number of the first class to be computed
 				    (pointer to the beginning of the linked list) */

--- a/src/lib/libderiv/mem_man.c
+++ b/src/lib/libderiv/mem_man.c
@@ -3,6 +3,8 @@
     \brief Enter brief description of file here 
 */
 #include<stdio.h>
+#include <string.h>
+#include <stdlib.h>
 #include"mem_man.h"
 #define MAXALLOC 10000
 

--- a/src/lib/libint/build_libint.c
+++ b/src/lib/libint/build_libint.c
@@ -46,7 +46,6 @@ char *real_type;   /*--- C type for real numbers ---*/
 int libint_stack_size[MAX_AM/2+1];
 LibintParams_t Params;
 
-void punt();
 int emit_vrr_build();
 int emit_vrr_build_macro();
 int emit_order();

--- a/src/lib/libint/build_libint.h
+++ b/src/lib/libint/build_libint.h
@@ -7,6 +7,8 @@
 #define DEFAULT_OPT_AM 8
 #define DEFAULT_MAX_CLASS_SIZE 785
 
+void punt(char* str);
+
 typedef struct {
 
   /* Twice the maximum AM for which manager routines need to be generated */

--- a/src/lib/libint/emit_order.c
+++ b/src/lib/libint/emit_order.c
@@ -8,6 +8,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include<stdlib.h>
 #include "mem_man.h"
 #include "build_libint.h"
 #include <libint/constants.h>
@@ -51,6 +52,13 @@ typedef struct vrr_node{
   int target;
   } vrr_class;
 
+
+int mk_hrr_node(hrr_class node, hrr_class *allnodes, int new);
+int mark_hrr_parents(int n, hrr_class *allnodes, int rent);
+int alloc_mem_hrr(hrr_class *nodes);
+int mk_vrr_node(vrr_class node, vrr_class *allnodes, int new);
+int mark_vrr_parents(int n, vrr_class *allnodes, int rent);
+int alloc_mem_vrr(vrr_class *nodes);
 
 static int first_hrr_to_compute = 0; /* Number of the first class to be computed
 				    (pointer to the beginning of the linked list) */

--- a/src/lib/libint/emit_vrr_build_macro.c
+++ b/src/lib/libint/emit_vrr_build_macro.c
@@ -5,6 +5,7 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "build_libint.h"
 #include <libint/constants.h>
 

--- a/src/lib/libint/mem_man.c
+++ b/src/lib/libint/mem_man.c
@@ -3,6 +3,8 @@
     \brief Enter brief description of file here 
 */
 #include<stdio.h>
+#include<string.h>
+#include<stdlib.h>
 #include"mem_man.h"
 #define MAXALLOC 10000
 

--- a/src/lib/libipv1/ip_read.cc
+++ b/src/lib/libipv1/ip_read.cc
@@ -14,6 +14,7 @@
 #include "ip_global.h"
 extern "C" {
 #include "y.tab.h"
+int yyparse(void);
 };
 
 #include "ip_read.gbl"
@@ -24,6 +25,7 @@ extern "C" {
 #include "ip_alloc.gbl"
 #include "ip_cwk.gbl"
 #include "ip_data.gbl"
+
 
 extern "C" {
 

--- a/src/lib/libipv1/parse.y
+++ b/src/lib/libipv1/parse.y
@@ -1,8 +1,20 @@
 %{
 #include <stdio.h>
 #include <tmpl.h>
+#include "ip_lib.h"
 #include "ip_types.h"
 #include "ip_read.gbl"
+int yylex(void);
+
+int
+yywrap()
+{return 1;}
+
+int
+yyerror(s)
+char *s;
+{ip_error(s);
+ return 0;}
 %}
 
 %union {
@@ -43,8 +55,7 @@ value:			array
 												{ $$ = $1; }
 			;
 
-array:			'(' values ')'
-												{ $$ = $2; }
+array:			'(' values ')' { $$ = $2; }
 			;
 
 values:			values value
@@ -59,12 +70,3 @@ scalar:			T_STRING
 
 %%
 
-int
-yywrap()
-{return 1;}
-
-int
-yyerror(s)
-char *s;
-{ip_error(s);
- return 0;}

--- a/src/lib/libipv1/scan.l
+++ b/src/lib/libipv1/scan.l
@@ -1,6 +1,7 @@
 %{
 #include <string.h>
 #include <tmpl.h>
+#include "ip_lib.h"
 #include "ip_types.h"
 #include "ip_global.h"
 #include "scan.gbl"

--- a/src/lib/libipv1/y.tab.h
+++ b/src/lib/libipv1/y.tab.h
@@ -1,0 +1,67 @@
+/* A Bison parser, made by GNU Bison 2.3.  */
+
+/* Skeleton interface for Bison's Yacc-like parsers in C
+
+   Copyright (C) 1984, 1989, 1990, 2000, 2001, 2002, 2003, 2004, 2005, 2006
+   Free Software Foundation, Inc.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2, or (at your option)
+   any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor,
+   Boston, MA 02110-1301, USA.  */
+
+/* As a special exception, you may create a larger work that contains
+   part or all of the Bison parser skeleton and distribute that work
+   under terms of your choice, so long as that work isn't itself a
+   parser generator using the skeleton or a modified version thereof
+   as a parser skeleton.  Alternatively, if you modify or redistribute
+   the parser skeleton itself, you may (at your option) remove this
+   special exception, which will cause the skeleton and the resulting
+   Bison output files to be licensed under the GNU General Public
+   License without this special exception.
+
+   This special exception was added by the Free Software Foundation in
+   version 2.2 of Bison.  */
+
+/* Tokens.  */
+#ifndef YYTOKENTYPE
+# define YYTOKENTYPE
+   /* Put the tokens into the symbol table, so that GDB and other debuggers
+      know about them.  */
+   enum yytokentype {
+     T_STRING = 258
+   };
+#endif
+/* Tokens.  */
+#define T_STRING 258
+
+
+
+
+#if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
+typedef union YYSTYPE
+#line 8 "/Users/crawdad/src/psi3/src/lib/libipv1/parse.y"
+{
+  ip_value_t *val;
+  char *str;
+  }
+/* Line 1529 of yacc.c.  */
+#line 60 "y.tab.h"
+	YYSTYPE;
+# define yystype YYSTYPE /* obsolescent; will be withdrawn */
+# define YYSTYPE_IS_DECLARED 1
+# define YYSTYPE_IS_TRIVIAL 1
+#endif
+
+extern YYSTYPE yylval;
+

--- a/src/lib/libr12/build_libr12.c
+++ b/src/lib/libr12/build_libr12.c
@@ -26,6 +26,7 @@
 
 #include <math.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <libint/libint.h>
 #include "build_libr12.h"
 #include <libint/constants.h>
@@ -35,13 +36,6 @@
 FILE *outfile, *vrr_header, *hrr_header, *libr12_header, *init_code;
 int libr12_stack_size[MAX_AM/2+1];
 Libr12Params_t Params;
-
-void punt();
-void emit_vrr_r_build();
-void emit_vrr_t_build();
-void emit_grt_order();
-void emit_gr_order();
-void emit_hrr_t_build();
 
 int main()
 {

--- a/src/lib/libr12/build_libr12.h
+++ b/src/lib/libr12/build_libr12.h
@@ -13,6 +13,15 @@
 #define DEFAULT_OPT_AM 6
 #define DEFAULT_MAX_CLASS_SIZE 785
 
+void punt(char* str);
+int emit_vrr_r_build(void);
+void emit_vrr_t_build(void);
+int emit_grt_order(void);
+void emit_gr_order(void);
+int emit_hrr_t_build(void);
+int emit_vrr_t1_build(void);
+int emit_vrr_t2_build(void);
+
 typedef struct {
 
   /* Twice the maximum AM for which manager routines need to be generated */

--- a/src/lib/libr12/emit_gr_order.c
+++ b/src/lib/libr12/emit_gr_order.c
@@ -53,7 +53,7 @@ static int first_vrr_to_compute = 0; /* Number of the first class to be computed
 static int hrr_hash_table[NUMGRTTYPES][2*LMAX_AM][2*LMAX_AM][2*LMAX_AM][2*LMAX_AM];
 static int vrr_hash_table[NUMGRTTYPES][2*LMAX_AM][2*LMAX_AM][4*LMAX_AM];
 
-int emit_grt_order()
+int emit_grt_order(void)
 {
   int old_am = Params.old_am;
   int new_am = Params.new_am;

--- a/src/lib/libr12/emit_grt_order.c
+++ b/src/lib/libr12/emit_grt_order.c
@@ -8,6 +8,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 #include <libint/libint.h>
 #include "mem_man.h"
 #include "build_libr12.h"
@@ -44,6 +45,13 @@ typedef struct node{
   int target;             /* Flag indicating that this node is among targets */
   } class;
 
+int mk_hrr_node(class node, class *allnodes, int new);
+int mark_hrr_parents(int n, class *allnodes, int rent);
+int alloc_mem_hrr(class *nodes);
+int mk_vrr_node(class node, class *allnodes, int new);
+int mark_vrr_parents(int n, class *allnodes, int rent);
+int alloc_mem_vrr(class *nodes);
+
 static int first_hrr_to_compute = 0; /* Number of the first class to be computed
 				    (pointer to the beginning of the linked list) */
 static int first_vrr_to_compute = 0; /* Number of the first class to be computed
@@ -54,7 +62,7 @@ static int first_vrr_to_compute = 0; /* Number of the first class to be computed
 static int hrr_hash_table[NUMGRTTYPES][2*LMAX_AM][2*LMAX_AM][2*LMAX_AM][2*LMAX_AM];
 static int vrr_hash_table[NUMGRTTYPES][2*LMAX_AM][2*LMAX_AM][4*LMAX_AM];
 
-int emit_grt_order()
+int emit_grt_order(void)
 {
   int old_am = Params.old_am;
   int new_am = Params.new_am;

--- a/src/lib/libr12/emit_hrr_t_build.c
+++ b/src/lib/libr12/emit_hrr_t_build.c
@@ -4,6 +4,7 @@
 */
 #include <math.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include "build_libr12.h"
 #include <libint/constants.h>
 
@@ -12,7 +13,7 @@ extern Libr12Params_t Params;
 
 extern void punt(char *);
 
-int emit_hrr_t_build()
+int emit_hrr_t_build(void)
 {
   int new_am = Params.new_am;
   int max_class_size = Params.max_class_size;

--- a/src/lib/libr12/emit_vrr_r_build.c
+++ b/src/lib/libr12/emit_vrr_r_build.c
@@ -5,6 +5,7 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "build_libr12.h"
 #include <libint/constants.h>
 
@@ -17,7 +18,7 @@ static void define_localv(int dec_C, int k1max, int k2max, int k3max, FILE *code
 
 static char **k1, **k2, **k3;
 
-int emit_vrr_r_build()
+int emit_vrr_r_build(void)
 {
   int old_am = Params.old_am;
   int new_am = Params.opt_am;

--- a/src/lib/libr12/emit_vrr_t1_build.c
+++ b/src/lib/libr12/emit_vrr_t1_build.c
@@ -5,6 +5,7 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "build_libr12.h"
 #include <libint/constants.h>
 
@@ -17,7 +18,7 @@ static void define_localv(int la, FILE *code);
 
 static char **k1;
 
-int emit_vrr_t1_build()
+int emit_vrr_t1_build(void)
 {
   int old_am = Params.old_am;
   int new_am = Params.opt_am;

--- a/src/lib/libr12/emit_vrr_t2_build.c
+++ b/src/lib/libr12/emit_vrr_t2_build.c
@@ -5,6 +5,7 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "build_libr12.h"
 #include <libint/constants.h>
 
@@ -17,7 +18,7 @@ static void define_localv(int lc, FILE *code);
 
 static char **k1;
 
-int emit_vrr_t2_build()
+int emit_vrr_t2_build(void)
 {
   int old_am = Params.old_am;
   int new_am = Params.opt_am;

--- a/src/lib/libr12/mem_man.c
+++ b/src/lib/libr12/mem_man.c
@@ -3,6 +3,8 @@
     \brief Enter brief description of file here 
 */
 #include<stdio.h>
+#include<stdlib.h>
+#include<string.h>
 #include"mem_man.h"
 #define MAXALLOC 10000
 


### PR DESCRIPTION
We needed access to some older local-CC functionality, so I made some corrections to allow for compilation on modern MacOS11 systems.  Specifically, I updated the `libipv1`, `libint`, `libderiv`, and `libr12` codes to correct many undeclared (or inconsistently declared) functions and moved a hard-wired `y.tab.h` file generated by GNU Bison into the main `libipv1` source directory.  